### PR TITLE
ci: auto run assign PR workflow

### DIFF
--- a/.github/workflows/assign-prs.yml
+++ b/.github/workflows/assign-prs.yml
@@ -15,18 +15,19 @@
 name: PR assignment
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize, reopened]
+  pull_request_target:
+    types: [opened, edited, reopened]
 
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - name: "Auto-assign PR"
         uses: pozil/auto-assign-issue@v2
         with:
-          assignees: minhaz,davidtamaki,drstrangelooker,LukaFontanilla,marcjwo,chrissieacodes,ipraveen9
+          assignees: minhaz,davidtamaki,drstrangelooker,LukaFontanilla,marcjwo,chrissieacodes
           numOfAssignee: 1
           abortIfPreviousAssignees: true


### PR DESCRIPTION
Updated PR assignment workflow to use pull_request_target event and adjusted assignees list.