### PR TITLE
ci: add env var before extension installation

### DIFF
--- a/.github/workflows/presubmit-tests.yml
+++ b/.github/workflows/presubmit-tests.yml
@@ -34,4 +34,6 @@ jobs:
           chmod +x toolbox
 
       - name: Install Extension
+        env:
+          GEMINI_API_KEY: "placeholder"
         run: yes | npx gemini extensions install .


### PR DESCRIPTION
recent update in gemini CLI require to set api key before running installation.