### PR TITLE
docs: update developer docs to use geminicli GCS bucket

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -33,7 +33,7 @@ The core logic for this extension is handled by a pre-built `toolbox` binary. Th
     VERSION=$(cat toolbox_version.txt)
 
     # Example for macOS/amd64
-    curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/v$VERSION/darwin/amd64/toolbox
+    curl -L -o toolbox https://storage.googleapis.com/genai-toolbox/geminicli/v$VERSION/darwin/amd64/toolbox
     chmod +x toolbox
     ```
     Adjust the URL for your operating system (`linux/amd64`, `darwin/arm64`, `windows/amd64`).


### PR DESCRIPTION
Replicates gemini-cli-extensions/cloud-sql-postgresql#106