### PR TITLE
feat: adopt Agent Plugin spec and generate harness manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "looker-conversational-analytics",
+  "owner": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "metadata": {
+    "description": "Connect to Looker Conversational Analytics."
+  },
+  "plugins": [
+    {
+      "name": "looker-conversational-analytics",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,90 @@
+{
+  "name": "looker-conversational-analytics",
+  "version": "0.3.7",
+  "description": "Connect to Looker Conversational Analytics",
+  "author": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "repository": "https://github.com/gemini-cli-extensions/looker-conversational-analytics",
+  "license": "Apache-2.0",
+  "userConfig": {
+    "looker_base_url": {
+      "title": "Base URL",
+      "description": "URL of the Looker instance",
+      "type": "string",
+      "sensitive": false
+    },
+    "looker_client_id": {
+      "title": "Client ID",
+      "description": "Client ID of the Looker API",
+      "type": "string",
+      "sensitive": false
+    },
+    "looker_client_secret": {
+      "title": "Client Secret",
+      "description": "Client Secret of the Looker API",
+      "type": "string",
+      "sensitive": true
+    },
+    "looker_verify_ssl": {
+      "title": "Verify SSL",
+      "description": "(Optional) Boolean to verify SSL certificates",
+      "type": "string",
+      "sensitive": false
+    },
+    "looker_project": {
+      "title": "Project",
+      "description": "The Google Cloud Project ID",
+      "type": "string",
+      "sensitive": false
+    },
+    "looker_location": {
+      "title": "Location",
+      "description": "The Google Cloud Location ID",
+      "type": "string",
+      "sensitive": false
+    },
+    "looker_show_hidden_models": {
+      "title": "Show Hidden Models",
+      "description": "(Optional) Boolean to show hidden models",
+      "type": "string",
+      "sensitive": false
+    },
+    "looker_show_hidden_explores": {
+      "title": "Show Hidden Explores",
+      "description": "(Optional) Boolean to show hidden explores",
+      "type": "string",
+      "sensitive": false
+    },
+    "looker_show_hidden_fields": {
+      "title": "Show Hidden Fields",
+      "description": "(Optional) Boolean to show hidden fields",
+      "type": "string",
+      "sensitive": false
+    }
+  },
+  "mcpServers": {
+    "looker": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "looker-conversational-analytics",
+        "--stdio"
+      ],
+      "env": {
+        "LOOKER_BASE_URL": "${user_config.looker_base_url}",
+        "LOOKER_CLIENT_ID": "${user_config.looker_client_id}",
+        "LOOKER_CLIENT_SECRET": "${user_config.looker_client_secret}",
+        "LOOKER_VERIFY_SSL": "${user_config.looker_verify_ssl}",
+        "LOOKER_PROJECT": "${user_config.looker_project}",
+        "LOOKER_LOCATION": "${user_config.looker_location}",
+        "LOOKER_SHOW_HIDDEN_MODELS": "${user_config.looker_show_hidden_models}",
+        "LOOKER_SHOW_HIDDEN_EXPLORES": "${user_config.looker_show_hidden_explores}",
+        "LOOKER_SHOW_HIDDEN_FIELDS": "${user_config.looker_show_hidden_fields}"
+      }
+    }
+  }
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -27,12 +27,6 @@
       "type": "string",
       "sensitive": true
     },
-    "looker_verify_ssl": {
-      "title": "Verify SSL",
-      "description": "(Optional) Boolean to verify SSL certificates",
-      "type": "string",
-      "sensitive": false
-    },
     "looker_project": {
       "title": "Project",
       "description": "The Google Cloud Project ID",
@@ -42,6 +36,12 @@
     "looker_location": {
       "title": "Location",
       "description": "The Google Cloud Location ID",
+      "type": "string",
+      "sensitive": false
+    },
+    "looker_verify_ssl": {
+      "title": "Verify SSL",
+      "description": "(Optional) Boolean to verify SSL certificates",
       "type": "string",
       "sensitive": false
     },
@@ -69,7 +69,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@toolbox-sdk/server@1.8.0",
+        "@toolbox-sdk/server@1.9.0",
         "--prebuilt",
         "looker-conversational-analytics",
         "--stdio"
@@ -78,9 +78,9 @@
         "LOOKER_BASE_URL": "${user_config.looker_base_url}",
         "LOOKER_CLIENT_ID": "${user_config.looker_client_id}",
         "LOOKER_CLIENT_SECRET": "${user_config.looker_client_secret}",
-        "LOOKER_VERIFY_SSL": "${user_config.looker_verify_ssl}",
         "LOOKER_PROJECT": "${user_config.looker_project}",
         "LOOKER_LOCATION": "${user_config.looker_location}",
+        "LOOKER_VERIFY_SSL": "${user_config.looker_verify_ssl}",
         "LOOKER_SHOW_HIDDEN_MODELS": "${user_config.looker_show_hidden_models}",
         "LOOKER_SHOW_HIDDEN_EXPLORES": "${user_config.looker_show_hidden_explores}",
         "LOOKER_SHOW_HIDDEN_FIELDS": "${user_config.looker_show_hidden_fields}"

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@toolbox-sdk/server@1.8.0",
+        "@toolbox-sdk/server@1.9.0",
         "--prebuilt",
         "looker-conversational-analytics",
         "--stdio"
@@ -13,9 +13,9 @@
         "LOOKER_BASE_URL",
         "LOOKER_CLIENT_ID",
         "LOOKER_CLIENT_SECRET",
-        "LOOKER_VERIFY_SSL",
         "LOOKER_PROJECT",
         "LOOKER_LOCATION",
+        "LOOKER_VERIFY_SSL",
         "LOOKER_SHOW_HIDDEN_MODELS",
         "LOOKER_SHOW_HIDDEN_EXPLORES",
         "LOOKER_SHOW_HIDDEN_FIELDS"

--- a/.codex-plugin/.mcp.json
+++ b/.codex-plugin/.mcp.json
@@ -1,0 +1,25 @@
+{
+  "mcpServers": {
+    "looker": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "looker-conversational-analytics",
+        "--stdio"
+      ],
+      "env_vars": [
+        "LOOKER_BASE_URL",
+        "LOOKER_CLIENT_ID",
+        "LOOKER_CLIENT_SECRET",
+        "LOOKER_VERIFY_SSL",
+        "LOOKER_PROJECT",
+        "LOOKER_LOCATION",
+        "LOOKER_SHOW_HIDDEN_MODELS",
+        "LOOKER_SHOW_HIDDEN_EXPLORES",
+        "LOOKER_SHOW_HIDDEN_FIELDS"
+      ]
+    }
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "looker-conversational-analytics",
+  "version": "0.3.7",
+  "description": "Connect to Looker Conversational Analytics",
+  "author": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "repository": "https://github.com/gemini-cli-extensions/looker-conversational-analytics",
+  "license": "Apache-2.0",
+  "mcpServers": "./.codex-plugin/.mcp.json"
+}

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ The plugin connects to Looker using these settings:
 *   `LOOKER_BASE_URL`: The URL of your Looker instance (e.g. `https://looker.example.com`). You may need to add the port, i.e. `:19999`.
 *   `LOOKER_CLIENT_ID`: Your Looker Client ID.
 *   `LOOKER_CLIENT_SECRET`: Your Looker Client Secret.
-*   `LOOKER_VERIFY_SSL`: (Optional) Whether to verify SSL certificates. Defaults to `true`.
 *   `LOOKER_PROJECT`: The Google Cloud Project ID.
 *   `LOOKER_LOCATION`: The Google Cloud Location ID.
+*   `LOOKER_VERIFY_SSL`: (Optional) Whether to verify SSL certificates. Defaults to `true`.
 
 How you supply them depends on the harness:
 
@@ -105,9 +105,9 @@ How you supply them depends on the harness:
 export LOOKER_BASE_URL="<your-looker-instance-url>"  # e.g. `https://looker.example.com`. You may need to add the port, i.e. `:19999`.
 export LOOKER_CLIENT_ID="<your-looker-client-id>"
 export LOOKER_CLIENT_SECRET="<your-looker-client-secret>"
-export LOOKER_VERIFY_SSL="true" # Optional, defaults to true
 export LOOKER_PROJECT="<your-google-cloud-project-id>"
 export LOOKER_LOCATION="<your-google-cloud-location-id>"
+export LOOKER_VERIFY_SSL="true" # Optional, defaults to true
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ Learn more about [Gemini CLI Extensions](https://github.com/google-gemini/gemini
 
 Before you begin, ensure you have the following:
 
-* [Gemini CLI](https://github.com/google-gemini/gemini-cli) installed with version **+v0.6.0**.
-* Setup Gemini CLI [Authentication](https://github.com/google-gemini/gemini-cli/tree/main?tab=readme-ov-file#-authentication-options).
+* One of the supported agent harnesses, installed and authenticated:
+  * [Gemini CLI](https://github.com/google-gemini/gemini-cli) (v0.6.0+)
+  * [Claude Code](https://code.claude.com)
+  * [Codex](https://developers.openai.com/codex)
+  * [Antigravity CLI](https://antigravity.google)
 * [Node.js](https://nodejs.org/) (the MCP server runs via `npx`).
 * A Looker instance with API access enabled.
     You will need a Looker Client Id and Client Secret. These can be obtained by following the directions at [Looker API authentication](https://cloud.google.com/looker/docs/api-auth#authentication_with_an_sdk).
@@ -51,15 +54,39 @@ Before you begin, ensure you have the following:
 
 ### Installation
 
-To install the extension, use the command:
+All harnesses use the same plugin; the MCP server runs via `npx` (no binary to download). Install with your harness of choice:
+
+**Gemini CLI**
 
 ```bash
 gemini extensions install https://github.com/gemini-cli-extensions/looker-conversational-analytics
 ```
 
+**Claude Code**
+
+```bash
+claude plugin marketplace add gemini-cli-extensions/looker-conversational-analytics
+claude plugin install looker-conversational-analytics@looker-conversational-analytics
+```
+
+**Codex**
+
+```bash
+codex plugin marketplace add gemini-cli-extensions/looker-conversational-analytics
+codex plugin add looker-conversational-analytics@looker-conversational-analytics
+```
+
+**Antigravity**
+
+```bash
+agy plugin install https://github.com/gemini-cli-extensions/looker-conversational-analytics
+```
+
+See [Configuration](#configuration) for how each harness supplies the connection settings.
+
 ### Configuration
 
-You will be prompted to configure the following settings during installation. These settings are saved in an `.env` file within the extension's directory.
+The plugin connects to Looker using these settings:
 
 *   `LOOKER_BASE_URL`: The URL of your Looker instance (e.g. `https://looker.example.com`). You may need to add the port, i.e. `:19999`.
 *   `LOOKER_CLIENT_ID`: Your Looker Client ID.
@@ -68,19 +95,11 @@ You will be prompted to configure the following settings during installation. Th
 *   `LOOKER_PROJECT`: The Google Cloud Project ID.
 *   `LOOKER_LOCATION`: The Google Cloud Location ID.
 
-To view or update your configuration:
+How you supply them depends on the harness:
 
-**List Settings:**
-*   Terminal: `gemini extensions list`
-*   Gemini CLI: `/extensions list`
-
-**Update Settings:**
-*   Terminal: `gemini extensions config looker-conversational-analytics [setting name] [--scope <scope>]`
-    *   `setting name`: (Optional) The single setting to configure.
-    *   `scope`: (Optional) The scope of the setting in (`user` or `workspace`). Defaults to `user`.
-*   Currently, you must restart the Gemini CLI for changes to take effect. We recommend using `gemini --resume` to resume your session.
-
-Alternatively, you can manually set these environment variables before starting the Gemini CLI:
+*   **Gemini CLI**: prompted on install and saved to the extension's `.env`. View or update later with `gemini extensions list` / `gemini extensions config looker-conversational-analytics [setting] [--scope user|workspace]` (restart the CLI to apply).
+*   **Claude Code**: pass `--config KEY=VALUE` on install (repeatable), or run `/plugin` inside Claude Code.
+*   **Codex** and **Antigravity**: export the variables in your shell before starting:
 
 ```bash
 export LOOKER_BASE_URL="<your-looker-instance-url>"  # e.g. `https://looker.example.com`. You may need to add the port, i.e. `:19999`.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -11,15 +11,7 @@
         "--prebuilt",
         "looker-conversational-analytics",
         "--stdio"
-      ],
-      "env": {
-        "LOOKER_BASE_URL": "${LOOKER_BASE_URL}",
-        "LOOKER_CLIENT_ID": "${LOOKER_CLIENT_ID}",
-        "LOOKER_CLIENT_SECRET": "${LOOKER_CLIENT_SECRET}",
-        "LOOKER_VERIFY_SSL": "${LOOKER_VERIFY_SSL}",
-        "LOOKER_PROJECT": "${LOOKER_PROJECT}",
-        "LOOKER_LOCATION": "${LOOKER_LOCATION}"
-      }
+      ]
     }
   },
   "contextFileName": "LOOKER-CONVERSATIONAL-ANALYTICS.md",
@@ -43,6 +35,16 @@
       "name": "Verify SSL",
       "description": "(Optional) Boolean to verify SSL certificates",
       "envVar": "LOOKER_VERIFY_SSL"
+    },
+    {
+      "name": "Project",
+      "description": "The Google Cloud Project ID",
+      "envVar": "LOOKER_PROJECT"
+    },
+    {
+      "name": "Location",
+      "description": "The Google Cloud Location ID",
+      "envVar": "LOOKER_LOCATION"
     },
     {
       "name": "Show Hidden Models",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -32,11 +32,6 @@
       "envVar": "LOOKER_CLIENT_SECRET"
     },
     {
-      "name": "Verify SSL",
-      "description": "(Optional) Boolean to verify SSL certificates",
-      "envVar": "LOOKER_VERIFY_SSL"
-    },
-    {
       "name": "Project",
       "description": "The Google Cloud Project ID",
       "envVar": "LOOKER_PROJECT"
@@ -45,6 +40,11 @@
       "name": "Location",
       "description": "The Google Cloud Location ID",
       "envVar": "LOOKER_LOCATION"
+    },
+    {
+      "name": "Verify SSL",
+      "description": "(Optional) Boolean to verify SSL certificates",
+      "envVar": "LOOKER_VERIFY_SSL"
     },
     {
       "name": "Show Hidden Models",

--- a/mcp.json
+++ b/mcp.json
@@ -6,7 +6,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@toolbox-sdk/server@1.8.0",
+        "@toolbox-sdk/server@1.9.0",
         "--prebuilt",
         "looker-conversational-analytics",
         "--stdio"

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "looker": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "looker-conversational-analytics",
+        "--stdio"
+      ]
+    }
+  }
+}

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@toolbox-sdk/server@1.8.0",
+        "@toolbox-sdk/server@1.9.0",
         "--prebuilt",
         "looker-conversational-analytics",
         "--stdio"

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "looker": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@toolbox-sdk/server@1.8.0",
+        "--prebuilt",
+        "looker-conversational-analytics",
+        "--stdio"
+      ]
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -28,11 +28,6 @@
           "sensitive": true
         },
         {
-          "key": "LOOKER_VERIFY_SSL",
-          "title": "Verify SSL",
-          "description": "(Optional) Boolean to verify SSL certificates"
-        },
-        {
           "key": "LOOKER_PROJECT",
           "title": "Project",
           "description": "The Google Cloud Project ID"
@@ -41,6 +36,11 @@
           "key": "LOOKER_LOCATION",
           "title": "Location",
           "description": "The Google Cloud Location ID"
+        },
+        {
+          "key": "LOOKER_VERIFY_SSL",
+          "title": "Verify SSL",
+          "description": "(Optional) Boolean to verify SSL certificates"
         },
         {
           "key": "LOOKER_SHOW_HIDDEN_MODELS",

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,67 @@
+{
+  "name": "looker-conversational-analytics",
+  "version": "0.3.7",
+  "description": "Connect to Looker Conversational Analytics",
+  "author": {
+    "name": "Google LLC",
+    "email": "data-cloud-ai-integrations@google.com"
+  },
+  "repository": "https://github.com/gemini-cli-extensions/looker-conversational-analytics",
+  "license": "Apache-2.0",
+  "extensions": {
+    "com.google.cloud.data.agent-plugins": {
+      "config": [
+        {
+          "key": "LOOKER_BASE_URL",
+          "title": "Base URL",
+          "description": "URL of the Looker instance"
+        },
+        {
+          "key": "LOOKER_CLIENT_ID",
+          "title": "Client ID",
+          "description": "Client ID of the Looker API"
+        },
+        {
+          "key": "LOOKER_CLIENT_SECRET",
+          "title": "Client Secret",
+          "description": "Client Secret of the Looker API",
+          "sensitive": true
+        },
+        {
+          "key": "LOOKER_VERIFY_SSL",
+          "title": "Verify SSL",
+          "description": "(Optional) Boolean to verify SSL certificates"
+        },
+        {
+          "key": "LOOKER_PROJECT",
+          "title": "Project",
+          "description": "The Google Cloud Project ID"
+        },
+        {
+          "key": "LOOKER_LOCATION",
+          "title": "Location",
+          "description": "The Google Cloud Location ID"
+        },
+        {
+          "key": "LOOKER_SHOW_HIDDEN_MODELS",
+          "title": "Show Hidden Models",
+          "description": "(Optional) Boolean to show hidden models"
+        },
+        {
+          "key": "LOOKER_SHOW_HIDDEN_EXPLORES",
+          "title": "Show Hidden Explores",
+          "description": "(Optional) Boolean to show hidden explores"
+        },
+        {
+          "key": "LOOKER_SHOW_HIDDEN_FIELDS",
+          "title": "Show Hidden Fields",
+          "description": "(Optional) Boolean to show hidden fields"
+        }
+      ],
+      "gemini": {
+        "contextFileName": "LOOKER-CONVERSATIONAL-ANALYTICS.md",
+        "mcpServerName": "looker"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adopts the Agent Plugin spec (`plugin.json` + `mcp.json`) and generates the per-harness manifests (Gemini, Claude, Codex, Antigravity) + `marketplace.json` + a multi-harness README, so one plugin works across all four.

Also drops the redundant `${LOOKER_*}` `env` block (Codex/AGY can't expand it) and adds `LOOKER_PROJECT`/`LOOKER_LOCATION` as config vars, so config flows through the per-harness config mechanism (Gemini settings, Claude userConfig, Codex `env_vars`, AGY ambient).

Generated with `agent-plugin-sync`; validate passes.
