### PR TITLE
feat: restore $schema in plugin.json for spec clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Before you begin, ensure you have the following:
 * One of the supported agent harnesses, installed and authenticated:
   * [Gemini CLI](https://github.com/google-gemini/gemini-cli) (v0.6.0+)
   * [Claude Code](https://code.claude.com)
-  * [Codex](https://developers.openai.com/codex)
+  * [Codex](https://developers.openai.com/codex) (v0.150.0+)
   * [Antigravity CLI](https://antigravity.google)
 * [Node.js](https://nodejs.org/) (the MCP server runs via `npx`).
 * A Looker instance with API access enabled.

--- a/plugin.json
+++ b/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "looker-conversational-analytics",
   "version": "0.3.8",
   "description": "Connect to Looker Conversational Analytics",


### PR DESCRIPTION
Restores `$schema` in `plugin.json`, so Agent Plugin spec clients recognise the manifest. It was omitted because Codex then read the spec `mcp.json` and ignored the `env_vars` in `.codex-plugin/`, leaving user config unforwarded.

Codex [0.150.0](https://github.com/openai/codex/commit/40b7560169c7274147a47f9b0c75db89fe016d34) removes that constraint: it reads the spec manifest and overlays the `.codex-plugin/` `env_vars` onto the matching servers.

Codex 0.150.0 is now stable (released 2026-08-26), so this is safe to merge. Users on 0.149.x and earlier will not get config forwarded to the MCP server until they upgrade.

Verified against the alpha with the `agent-plugin-sync` integration suite: 4/4 harnesses pass on 0.150.0-alpha.11, and the Codex test fails on 0.147.0, which is exactly the behaviour this PR depends on.

README also notes the new Codex version requirement. Generated manifests are unchanged, since `$schema` does not propagate into them.

